### PR TITLE
feat(observability): persistent structured error log in Memory

### DIFF
--- a/src/kernel/ErrorMapper.ts
+++ b/src/kernel/ErrorMapper.ts
@@ -42,6 +42,69 @@ function getConsumer(): SourceMapConsumer {
 
 const _traceCache: Record<string, string> = {};
 
+// ---------------------------------------------------------------------------
+// Persistent error log — survives global resets via Memory.errorLog
+// ---------------------------------------------------------------------------
+
+const ERROR_LOG_MAX_ENTRIES = 50;
+
+/**
+ * Compute a short djb2 hash of the first 500 chars of a stack string.
+ * Used as a stable Memory key so identical errors deduplicate across ticks.
+ */
+function stackFingerprint(stack: string): string {
+    let h = 5381;
+    const limit = Math.min(stack.length, 500);
+    for (let i = 0; i < limit; i++) {
+        h = ((h << 5) + h + stack.charCodeAt(i)) | 0;
+    }
+    return (h >>> 0).toString(36);
+}
+
+/**
+ * Upsert an error into the persistent Memory.errorLog.
+ * - If the same stack fingerprint already exists: increment count + update lastTick/bucket.
+ * - If new: map the stack trace (expensive once), store the full entry.
+ * - Evicts the oldest entry when the log exceeds ERROR_LOG_MAX_ENTRIES.
+ */
+function upsertErrorLog(rawStack: string, mappedStack: string, message: string): void {
+    if (!Memory.errorLog) {
+        Memory.errorLog = {};
+    }
+
+    const key = stackFingerprint(rawStack);
+    const existing = Memory.errorLog[key];
+
+    if (existing) {
+        existing.count++;
+        existing.lastTick = Game.time;
+        existing.bucket = Game.cpu.bucket;
+    } else {
+        // Evict the oldest entry if at capacity
+        const entries = Object.entries(Memory.errorLog);
+        if (entries.length >= ERROR_LOG_MAX_ENTRIES) {
+            let oldestKey = entries[0][0];
+            let oldestTick = entries[0][1].lastTick;
+            for (const [k, v] of entries) {
+                if (v.lastTick < oldestTick) {
+                    oldestTick = v.lastTick;
+                    oldestKey = k;
+                }
+            }
+            delete Memory.errorLog[oldestKey];
+        }
+
+        Memory.errorLog[key] = {
+            message,
+            mappedStack,
+            firstTick: Game.time,
+            lastTick: Game.time,
+            count: 1,
+            bucket: Game.cpu.bucket,
+        };
+    }
+}
+
 /**
  * Map a raw V8 stack trace back to original TypeScript source locations.
  *
@@ -122,7 +185,7 @@ export const ErrorMapper = {
 
     /**
      * Wraps the game loop so uncaught errors are caught, source-mapped,
-     * and logged to the console without crashing subsequent ticks.
+     * logged to the console, and persisted to Memory.errorLog.
      */
     wrapLoop(fn: () => void): () => void {
         return (): void => {
@@ -131,15 +194,53 @@ export const ErrorMapper = {
             } catch (e: unknown) {
                 if (e instanceof Error) {
                     if ("sim" in Game.rooms) {
-                        log.error(`Source maps unavailable in sim\n${sanitize(e.stack || e.message)}`);
+                        const raw = e.stack || e.message;
+                        log.error(`Source maps unavailable in sim\n${sanitize(raw)}`);
+                        upsertErrorLog(raw, raw, e.message);
                     } else {
-                        log.error(sanitize(sourceMappedStackTrace(e)));
+                        const mapped = sourceMappedStackTrace(e);
+                        log.error(sanitize(mapped));
+                        upsertErrorLog(e.stack ?? e.message, mapped, e.message);
                     }
                 } else {
-                    log.error(`Non-Error thrown: ${sanitize(String(e))}`);
+                    const msg = `Non-Error thrown: ${String(e)}`;
+                    log.error(sanitize(msg));
+                    upsertErrorLog(msg, msg, msg);
                 }
             }
         };
+    },
+
+    /**
+     * Persist an error to Memory.errorLog without re-throwing.
+     * Use this for non-fatal errors caught inline (e.g. TrafficManager crashes).
+     */
+    persistError(e: Error | string): void {
+        try {
+            const isError = e instanceof Error;
+            const message = isError ? e.message : String(e);
+            const rawStack = isError ? (e.stack ?? message) : message;
+            const mapped = "sim" in Game.rooms ? rawStack : sourceMappedStackTrace(isError ? e : rawStack);
+            upsertErrorLog(rawStack, mapped, message);
+        } catch {
+            // Never let the error logger itself throw
+        }
+    },
+
+    /**
+     * Returns all persisted error log entries sorted by lastTick descending
+     * (most recently seen first).
+     */
+    getErrorLog(): ErrorLogEntry[] {
+        if (!Memory.errorLog) return [];
+        return Object.values(Memory.errorLog).sort((a, b) => b.lastTick - a.lastTick);
+    },
+
+    /**
+     * Wipe the persistent error log.
+     */
+    clearErrorLog(): void {
+        Memory.errorLog = {};
     },
 
     /**

--- a/src/main.ts
+++ b/src/main.ts
@@ -50,6 +50,31 @@ const log = new Logger("OS");
 };
 
 /**
+ * Print the persistent error log sorted by most-recently-seen.
+ * Run from the Screeps console: showErrors()
+ */
+(global as any).showErrors = (): string => {
+    const entries = ErrorMapper.getErrorLog();
+    if (entries.length === 0) {
+        return "No errors logged.";
+    }
+    const lines = entries.map((e, i) => {
+        const recency = e.count > 1 ? ` ×${e.count}, last tick ${e.lastTick}` : ` tick ${e.firstTick}`;
+        return `[${i + 1}] ${e.message}${recency} (bucket ${e.bucket})\n${e.mappedStack}`;
+    });
+    return lines.join("\n\n");
+};
+
+/**
+ * Clear the persistent error log.
+ * Run from the Screeps console: clearErrors()
+ */
+(global as any).clearErrors = (): string => {
+    ErrorMapper.clearErrorLog();
+    return "Error log cleared.";
+};
+
+/**
  * Full bot reset — wipes Memory, heap, and forces a fresh bootstrap.
  * Run from the Screeps console: resetBot()
  */
@@ -203,8 +228,10 @@ export const loop = ErrorMapper.wrapLoop(() => {
     try {
         TrafficManager.run();
     } catch (e: unknown) {
-        const msg = e instanceof Error ? e.stack ?? e.message : String(e);
-        log.error(`TrafficManager crashed (non-fatal):\n${ErrorMapper.mapTrace(msg)}`);
+        const err = e instanceof Error ? e : new Error(String(e));
+        const mapped = ErrorMapper.mapTrace(err.stack ?? err.message);
+        log.error(`TrafficManager crashed (non-fatal):\n${mapped}`);
+        ErrorMapper.persistError(err);
     }
 
     // --- 9. Persist state (Heap-First) ---

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -63,6 +63,22 @@ interface RoomMemory {
     [key: string]: any;
 }
 
+/** A deduplicated, persistent entry in the error log */
+interface ErrorLogEntry {
+    /** Error message string */
+    message: string;
+    /** Source-mapped stack trace (resolved once on first occurrence) */
+    mappedStack: string;
+    /** Game.time when this error was first seen */
+    firstTick: number;
+    /** Game.time when this error was most recently seen */
+    lastTick: number;
+    /** Total number of occurrences */
+    count: number;
+    /** Game.cpu.bucket at the time of the most recent occurrence */
+    bucket: number;
+}
+
 interface Memory {
     kernel: KernelMemory;
     creeps: { [name: string]: CreepMemory };
@@ -70,6 +86,8 @@ interface Memory {
     logLevel?: number;
     /** Arbitrary heap-persistent data storage */
     heap?: Record<string, unknown>;
+    /** Persistent cross-tick error log — survives global resets */
+    errorLog?: Record<string, ErrorLogEntry>;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements the persistent error log recommended by the observability
research. Errors caught in the main loop and TrafficManager are now
deduplicated by djb2 stack fingerprint and stored across ticks and
global resets in Memory.errorLog (up to 50 entries, LRU eviction).

Key changes:
- ErrorMapper.ts: add upsertErrorLog() with djb2 fingerprinting,
  dedup (count + lastTick update), oldest-entry eviction, and three
  new public methods — persistError(), getErrorLog(), clearErrorLog()
- ErrorMapper.wrapLoop(): calls upsertErrorLog() on every caught error
- main.ts: TrafficManager catch calls ErrorMapper.persistError() so
  non-fatal inline errors are also logged
- main.ts: adds showErrors() and clearErrors() console commands
- types.d.ts: adds ErrorLogEntry interface and Memory.errorLog field

https://claude.ai/code/session_011FdG2aaarvmZmJYYWK8yod