### PR TITLE
fix(bootstrapper): add maxEnergy to all bootstrap spawn requests

### DIFF
--- a/src/os/overlords/BootstrappingOverlord.ts
+++ b/src/os/overlords/BootstrappingOverlord.ts
@@ -84,6 +84,7 @@ export class BootstrappingOverlord extends Overlord {
             this.colony.hatchery.enqueue({
                 priority: BOOTSTRAP_PRIORITY,
                 bodyTemplate: [CARRY, MOVE],
+                maxEnergy: 100,
                 overlord: this,
                 name: `bootstrap_hauler_${this.colony.name}_${Game.time}`,
                 memory: { role: "bootstrapper" }
@@ -96,6 +97,7 @@ export class BootstrappingOverlord extends Overlord {
             this.colony.hatchery.enqueue({
                 priority: BOOTSTRAP_PRIORITY,
                 bodyTemplate: [WORK, MOVE],
+                maxEnergy: 150,
                 overlord: this,
                 name: `bootstrap_dropminer_${this.colony.name}_${Game.time}`,
                 memory: { role: "bootstrapper" }
@@ -105,6 +107,7 @@ export class BootstrappingOverlord extends Overlord {
                 this.colony.hatchery.enqueue({
                     priority: BOOTSTRAP_PRIORITY,
                     bodyTemplate: [CARRY, MOVE],
+                    maxEnergy: 100,
                     overlord: this,
                     name: `bootstrap_relay_${this.colony.name}_${Game.time}`,
                     memory: { role: "bootstrapper" }
@@ -116,6 +119,7 @@ export class BootstrappingOverlord extends Overlord {
             this.colony.hatchery.enqueue({
                 priority: BOOTSTRAP_PRIORITY,
                 bodyTemplate: [WORK, CARRY, MOVE],
+                maxEnergy: 200,
                 overlord: this,
                 name: `bootstrap_pioneer_${this.colony.name}_${Game.time}`,
                 memory: { role: "bootstrapper" }
@@ -127,6 +131,7 @@ export class BootstrappingOverlord extends Overlord {
             this.colony.hatchery.enqueue({
                 priority: BOOTSTRAP_PRIORITY,
                 bodyTemplate: [WORK, CARRY, MOVE],
+                maxEnergy: 200,
                 overlord: this,
                 name: `bootstrap_pioneer_${this.colony.name}_${Game.time}`,
                 memory: { role: "bootstrapper" }


### PR DESCRIPTION
Hatchery.run() scales bodies to energyCapacityAvailable when no maxEnergy
is set. During a critical blackout, energyAvailable is far below capacity,
so the scaled body cost always exceeds virtualEnergyAvailable and the
Hatchery breaks without ever calling spawnCreep. Because spawnCreep never
fires, spawn.spawning is never set, the guard in init() never returns early,
and the overlord re-enqueues every tick — producing the repeating log but
no creep.

Fix: cap each bootstrap body at its exact minimum viable cost:
  [CARRY, MOVE]       → maxEnergy: 100
  [WORK, MOVE]        → maxEnergy: 150
  [WORK, CARRY, MOVE] → maxEnergy: 200

https://claude.ai/code/session_01MtUC8LqphSM7SqvnZPcEPq