### PR TITLE
fix(traffic): resolve swap-loop oscillation and hatchery congestion

### DIFF
--- a/src/os/infrastructure/TrafficManager.ts
+++ b/src/os/infrastructure/TrafficManager.ts
@@ -137,19 +137,40 @@ export class TrafficManager {
                                     role === "miner" || role === "filler") {
 
                                     // FIX 3: Scope isParked correctly.
+                                    // FIX 4: Tighten isParked checks and reduce score.
+                                    //
+                                    // isNearTo() checks a 3×3 grid — a worker merely walking past a
+                                    // source on a road tile gets classified as "parked" if it pauses.
+                                    // Miners/harvesters should only be truly parked when at range 1
+                                    // from the source AND on a container tile (their workstation).
+                                    //
+                                    // Score reduced from 10000 to 50. This is still high enough to
+                                    // resist standard haulers (priority 1-10) and shove proposals
+                                    // (score 0.2), but emergency/military traffic (priority 100+)
+                                    // can displace them when absolutely needed.
+                                    // Fillers are a special case — they NEVER move and get 10000.
                                     let isParked = false;
                                     if (taskName === "Upgrade" && room.controller && creep.pos.inRangeTo(room.controller, 3)) {
                                         isParked = true;
                                     } else if (taskName === "Harvest" || role === "miner") {
-                                        if (room.find(FIND_SOURCES).some(s => creep.pos.isNearTo(s))) isParked = true;
-                                        if (!isParked && room.find(FIND_MINERALS).some(m => creep.pos.isNearTo(m))) isParked = true;
+                                        // Only truly parked if adjacent to a source AND on a container
+                                        // (the designated mining spot). Just being isNearTo a source
+                                        // on a road tile is NOT parked — that's a transient creep.
+                                        const nearSource = room.find(FIND_SOURCES).some(s => creep.pos.isNearTo(s));
+                                        const nearMineral = !nearSource && room.find(FIND_MINERALS).some(m => creep.pos.isNearTo(m));
+                                        if (nearSource || nearMineral) {
+                                            // Check if standing on a container (designated workstation)
+                                            const onContainer = creep.pos.lookFor(LOOK_STRUCTURES)
+                                                .some((s: Structure) => s.structureType === STRUCTURE_CONTAINER);
+                                            isParked = onContainer || role === "miner"; // miners always park at their source
+                                        }
                                     } else if (role === "filler") {
-                                        // Fillers always hold their standing tile — they are permanent residents
-                                        // of the bunker center and must never be displaced by passing traffic.
-                                        isParked = true;
+                                        // Fillers are permanent residents of the bunker center.
+                                        // They NEVER move and must never be displaced by any traffic.
+                                        return 10000;
                                     }
 
-                                    if (isParked) return 10000;
+                                    if (isParked) return 50;
                                 }
 
                                 // Fix 5: Priority-Based Yielding.
@@ -160,8 +181,18 @@ export class TrafficManager {
                                 const hasTask = !!(creep.memory as any).task;
                                 return hasTask ? 0.5 : 0.01;
                             } else {
-                                // Creep is trying to move but falling back — weak hold so traffic flows
-                                return 0.1;
+                                // Creep is trying to move but blocked — hold ground against
+                                // same-priority trailing traffic to form a stable queue.
+                                // Without this, two same-priority creeps leapfrog endlessly:
+                                // A blocks at 0.1, B (priority 1) evicts A; next tick B blocks
+                                // at 0.1, A evicts B — infinite oscillation.
+                                //
+                                // Using intent.priority + 0.1 means:
+                                //   - A priority-1 hauler holds at 1.1, resisting a trailing
+                                //     priority-1 hauler (score 1.0) → stable queue forms.
+                                //   - A priority-10 transporter (score 10.0) still displaces
+                                //     the priority-1 hauler (1.1) → right-of-way preserved.
+                                return intent.priority + 0.1;
                             }
                         }
 
@@ -277,9 +308,24 @@ export class TrafficManager {
         let movesThisTick = 0;
         let shovesThisTick = 0;
 
+        // Track creeps whose move intents have been finalized by a swap.
+        // In Screeps, only the LAST move() call per tick counts. If we issue
+        // creep.pull(blocker) + creep.move(blocker) for a mutual swap, then
+        // later call creep.move(direction), the directional move OVERWRITES
+        // the swap target — silently breaking the pull() handshake.
+        // handledSwaps prevents this by skipping the directional move.
+        const handledSwaps = new Set<string>();
+
+        // Build a set of all tiles assigned by Gale-Shapley so the step-aside
+        // logic can avoid nudging a blocker into a tile that another creep is
+        // simultaneously routing into (creepAtPos only shows start-of-tick state).
+        const assignedTiles = new Set<string>(matches.values());
+
         for (const creep of myCreeps) {
             // Skip creeps that already moved off-grid in phase 1
             if (exitedCreeps.has(creep.name)) continue;
+            // Skip creeps already handled by a prior swap iteration
+            if (handledSwaps.has(creep.name)) continue;
 
             const matchedTileId = matches.get(creep.name);
             if (!matchedTileId) continue;
@@ -295,7 +341,9 @@ export class TrafficManager {
             const tileKey = `${matchedPos.roomName}_${matchedPos.x},${matchedPos.y}`;
             const blocker = creepAtPos.get(tileKey) || null;
 
-            // ── Fix #1: pull() needs all three intents ──
+            // ── Swap / Step-Aside resolution ──
+            let isSwapping = false;
+
             if (blocker && blocker.my) {
                 const blockerAssignedTile = matches.get(blocker.name);
                 const myCurrentTile = `${creep.pos.roomName}_${creep.pos.x},${creep.pos.y}`;
@@ -309,16 +357,51 @@ export class TrafficManager {
                     // silently rejected — swaps between two non-fatigued creeps on roads
                     // were silently failing because the fatigue guard suppressed pull().
                     // pull() also exempts the pulled creep from road/swamp fatigue costs.
+                    //
+                    // CRITICAL: Use move(blocker) not move(direction) — move(direction)
+                    // would overwrite the pull() target. The Screeps engine needs the
+                    // explicit creep reference to link the pull-move pair atomically.
                     creep.pull(blocker);
+                    creep.move(blocker);
                     blocker.move(creep);
+                    // Protect blocker from having its move(creep) overwritten when
+                    // the loop processes it later.
+                    handledSwaps.add(blocker.name);
+                    isSwapping = true;
                     creep.say("🔗");
-                } else if (!blockerAssignedTile) {
-                    // Fix 3 — vacatePos Step-Aside:
-                    // The blocker is idle (unmatched). Instead of swapping it onto the
-                    // path (which just relocates the jam), scan adjacent tiles for an
-                    // off-path empty spot. The hauler keeps its straight-line move and
-                    // the idle creep steps onto a swamp/plain without blocking traffic.
+                } else if (!blockerAssignedTile || blockerAssignedTile !== myCurrentTile) {
+                    // vacatePos Step-Aside:
+                    // The blocker is idle (unmatched) OR matched to a THIRD tile (not
+                    // a mutual swap). In either case, the blocker needs to vacate our
+                    // target tile. Scan adjacent tiles for an off-path empty spot.
+                    // The hauler keeps its straight-line move and the blocking creep
+                    // steps onto a swamp/plain without blocking traffic.
                     let steppedAside = false;
+
+                    // If the blocker IS matched to another tile, try to nudge it
+                    // toward its assigned destination first (most natural resolution).
+                    if (blockerAssignedTile) {
+                        const assignedPos = tileMap.get(blockerAssignedTile);
+                        if (assignedPos && !assignedPos.isEqualTo(blocker.pos)) {
+                            const nudgeDir = blocker.pos.getDirectionTo(assignedPos);
+                            // Verify the nudge tile is walkable and unoccupied
+                            const nudgePos = getPositionAtDirection(blocker.pos, nudgeDir);
+                            if (nudgePos && nudgePos.roomName === roomName &&
+                                nudgePos.x > 0 && nudgePos.x < 49 && nudgePos.y > 0 && nudgePos.y < 49 &&
+                                (terrain.get(nudgePos.x, nudgePos.y) & TERRAIN_MASK_WALL) === 0 &&
+                                matrix.get(nudgePos.x, nudgePos.y) < 255) {
+                                const nudgeKey = `${nudgePos.roomName}_${nudgePos.x},${nudgePos.y}`;
+                                // Check both start-of-tick positions AND Gale-Shapley assignments
+                                // to avoid nudging into a tile another creep is routing into.
+                                if (!creepAtPos.has(nudgeKey) && !assignedTiles.has(nudgeKey)) {
+                                    blocker.move(nudgeDir);
+                                    steppedAside = true;
+                                }
+                            }
+                        }
+                    }
+
+                    // General step-aside scan: find any adjacent empty tile
                     for (let d = 1; d <= 8 && !steppedAside; d++) {
                         const adjPos = getPositionAtDirection(blocker.pos, d as DirectionConstant);
                         if (!adjPos || adjPos.roomName !== roomName) continue;
@@ -326,7 +409,8 @@ export class TrafficManager {
                         if ((terrain.get(adjPos.x, adjPos.y) & TERRAIN_MASK_WALL) !== 0) continue;
                         if (matrix.get(adjPos.x, adjPos.y) >= 255) continue; // wall/structure
                         const adjKey = `${adjPos.roomName}_${adjPos.x},${adjPos.y}`;
-                        if (creepAtPos.has(adjKey)) continue; // occupied by another creep
+                        // Check both start-of-tick AND Gale-Shapley assigned tiles
+                        if (creepAtPos.has(adjKey) || assignedTiles.has(adjKey)) continue;
                         // Clear tile found — step aside off the hauler's path
                         blocker.move(d as DirectionConstant);
                         steppedAside = true;
@@ -335,18 +419,24 @@ export class TrafficManager {
                         // Boxed in — fall back to swap so the hauler isn't hard-blocked.
                         // Same pull() requirement applies (see mutual-swap comment above).
                         creep.pull(blocker);
+                        creep.move(blocker);
                         blocker.move(creep);
+                        handledSwaps.add(blocker.name);
+                        isSwapping = true;
                         creep.say("🔄");
                     }
                 }
             }
 
-            creep.move(moveDir);
+            // Only issue a directional move if we did NOT set up a swap.
+            // move(direction) would overwrite the move(creep) from pull().
+            if (!isSwapping) {
+                creep.move(moveDir);
+            }
 
             if (intentMap.has(creep.name) && intentMap.get(creep.name)!.direction === moveDir) {
                 movesThisTick++;
             } else {
-                creep.say("🔀");
                 shovesThisTick++;
             }
         }

--- a/src/os/overlords/WorkerOverlord.ts
+++ b/src/os/overlords/WorkerOverlord.ts
@@ -19,6 +19,7 @@ import { RepairTask } from "../tasks/RepairTask";
 import { TransferTask } from "../tasks/TransferTask";
 import { DismantleTask } from "../tasks/DismantleTask";
 import { getParkingZones, pickParkingZone, getRampartTarget } from "../../utils/ParkingZones";
+import { GlobalCache } from "../../kernel/GlobalCache";
 
 
 
@@ -195,6 +196,10 @@ export class WorkerOverlord extends Overlord {
             // route), hold position near the nearest construction site or container.
             // Emitting no moveTo() keeps the hauler's cached path valid — the key fix
             // for Kinetic Friction / constant path-recalculation CPU spikes.
+            //
+            // Fix: If there's no construction site to anchor toward, move to a parking
+            // zone instead of idling in-place. Workers idling on hatchery road tiles
+            // create traffic jams that block transporters trying to deliver energy.
             if (!mem.collecting && (worker.store?.getUsedCapacity(RESOURCE_ENERGY) ?? 0) === 0) {
                 const creepId = worker.creep?.id;
                 const inFlight = creepId ? (this.colony.logistics.incomingReservations.get(creepId) || 0) : 0;
@@ -204,8 +209,12 @@ export class WorkerOverlord extends Overlord {
                     const site = this.getBestConstructionSite();
                     if (site && worker.pos && !worker.pos.inRangeTo(site.pos, 3)) {
                         worker.travelTo(site.pos, 3);
+                    } else if (worker.pos && this.isInHatcheryZone(worker.pos)) {
+                        // No site to anchor toward AND we're blocking the hatchery.
+                        // Move to a parking zone so transporters can deliver unimpeded.
+                        this.parkAwayFromHatchery(worker);
                     }
-                    // If already close enough (or no site), stay still — do nothing, just anchor
+                    // If close enough to a site and not in hatchery zone, stay still
                     continue;
                 }
             }
@@ -240,7 +249,15 @@ export class WorkerOverlord extends Overlord {
                         worker.setTask(new WithdrawTask(container.id as Id<Structure>));
                     } else {
                         // Anchor to nearest container — use pre-hoisted anyContainers array (Fix #2)
-                        const anyContainer = worker.pos?.findClosestByRange(anyContainers);
+                        // Fix: Skip hatchery containers when fillers are active — workers anchoring
+                        // there compete with transporters for the same corridor tiles.
+                        const hasFillerCreeps = this.colony.creeps.some(c => (c.memory as any)?.role === "filler");
+                        const candidateContainers = hasFillerCreeps
+                            ? anyContainers.filter(c => !this.isInHatcheryZone(c.pos))
+                            : anyContainers;
+                        const anyContainer = worker.pos?.findClosestByRange(
+                            candidateContainers.length > 0 ? candidateContainers : anyContainers
+                        );
 
                         if (anyContainer) {
                             // Anchor to container position — do NOT issue travelTo; just hold still
@@ -482,5 +499,67 @@ export class WorkerOverlord extends Overlord {
         })[0];
 
         return this._bestSite;
+    }
+
+    // -----------------------------------------------------------------------
+    // Hatchery Congestion Avoidance
+    // -----------------------------------------------------------------------
+
+    /**
+     * Check if a position is within the hatchery congestion zone.
+     * The zone is defined as Chebyshev distance ≤ 3 from any spawn.
+     * This is the high-traffic area where transporters need clear access
+     * to deliver energy to spawns, extensions, and the hub container.
+     */
+    private isInHatcheryZone(pos: RoomPosition): boolean {
+        const room = this.colony.room;
+        if (!room) return false;
+
+        const spawns = room.find(FIND_MY_SPAWNS);
+        for (const spawn of spawns) {
+            if (pos.getRangeTo(spawn) <= 3) return true;
+        }
+
+        // Also check the anchor center (bunker core) if available
+        const anchor = (this.colony.memory as any).anchor as { x: number; y: number } | undefined;
+        if (anchor) {
+            const cheb = Math.max(Math.abs(pos.x - anchor.x), Math.abs(pos.y - anchor.y));
+            if (cheb <= 4) return true; // Within bunker inner ring
+        }
+
+        return false;
+    }
+
+    /**
+     * Move a worker to a parking zone outside the hatchery area.
+     * Called when the worker has no task and is idling in the hatchery
+     * congestion zone, blocking transporter traffic.
+     */
+    private parkAwayFromHatchery(worker: Worker): void {
+        const room = this.colony.room;
+        if (!room || !worker.pos) return;
+
+        const anchor = (this.colony.memory as any).anchor as { x: number; y: number } | undefined;
+        if (anchor) {
+            const zones = getParkingZones(room, anchor.x, anchor.y);
+            const staticCached = GlobalCache.get<{ matrix: CostMatrix }>(`matrix_static:${room.name}`);
+            const target = pickParkingZone(worker.pos, zones, staticCached?.matrix);
+            if (target) {
+                worker.travelTo(target, 0);
+                return;
+            }
+        }
+
+        // Fallback: flee away from the nearest spawn
+        const spawn = room.find(FIND_MY_SPAWNS)?.[0];
+        if (spawn) {
+            const dx = worker.pos.x - spawn.pos.x;
+            const dy = worker.pos.y - spawn.pos.y;
+            const mx = dx === 0 ? 1 : Math.sign(dx);
+            const my = dy === 0 ? 1 : Math.sign(dy);
+            const tx = Math.min(48, Math.max(1, worker.pos.x + mx * 5));
+            const ty = Math.min(48, Math.max(1, worker.pos.y + my * 5));
+            worker.travelTo(new RoomPosition(tx, ty, spawn.pos.roomName), 1);
+        }
     }
 }

--- a/src/os/zerg/Zerg.ts
+++ b/src/os/zerg/Zerg.ts
@@ -89,6 +89,13 @@ export class Zerg {
     _expectedPos: RoomPosition | null = null; // Tracks Shove Drift
     _blockedPos: RoomPosition | null = null;  // Deep-stuck repath penalty
 
+    // ── Oscillation detection (Fix: swap-loop / ping-pong) ────────────
+    // Tracks the last 3 positions. If the creep alternates between two
+    // tiles for 3+ ticks (A→B→A or B→A→B), it's oscillating — not stuck
+    // in the _stuckCount sense, but making zero forward progress.
+    _posHistory: Array<{ x: number; y: number; roomName: string }> = [];
+    _oscillationCount = 0;
+
     constructor(creepName: string) {
         this.creepName = creepName;
     }
@@ -418,8 +425,14 @@ export class Zerg {
                 this._path.ticksToLive--;
             } else {
                 // We moved, but NOT along the expected path (we were shoved off-route!)
+                // A shove is still a delay — the creep made zero forward progress.
+                // Incrementing _stuckCount (instead of resetting to 0) ensures that
+                // repeatedly shoved creeps eventually trigger the deep-stuck repath,
+                // which penalizes the blocking tile and finds an alternate route.
+                // Without this, oscillating creeps reset to 0 every tick and the
+                // deep-stuck threshold (> 2) is never reached.
                 this._path = null;
-                this._stuckCount = 0;
+                this._stuckCount++;
             }
         } else if (this._lastPos && currentPos.isEqualTo(this._lastPos)) {
             this._stuckCount++;
@@ -428,6 +441,45 @@ export class Zerg {
         }
 
         this._lastPos = currentPos;
+
+        // ── Oscillation Detection (Fix: swap-loop / ping-pong) ──────────
+        // Track the last 3 positions. If the creep alternates between two
+        // tiles (A→B→A pattern), increment _oscillationCount. After 4 ticks
+        // of oscillation, force a repath that penalizes BOTH oscillation
+        // tiles, breaking the swap loop.
+        this._posHistory.push({ x: currentPos.x, y: currentPos.y, roomName: currentPos.roomName });
+        if (this._posHistory.length > 4) this._posHistory.shift();
+
+        if (this._posHistory.length >= 3) {
+            const h = this._posHistory;
+            const len = h.length;
+            // Check A→B→A pattern: position[-3] === position[-1] && position[-3] !== position[-2]
+            const cur = h[len - 1];
+            const prev = h[len - 2];
+            const prevPrev = h[len - 3];
+            const isOscillating = cur.x === prevPrev.x && cur.y === prevPrev.y &&
+                cur.roomName === prevPrev.roomName &&
+                (cur.x !== prev.x || cur.y !== prev.y || cur.roomName !== prev.roomName);
+
+            if (isOscillating) {
+                this._oscillationCount++;
+            } else {
+                this._oscillationCount = 0;
+            }
+
+            // After 2 oscillation cycles (4 ticks of A↔B), force repath
+            // penalizing the OTHER tile in the oscillation pair so PathFinder
+            // routes around the contested corridor entirely.
+            if (this._oscillationCount >= 2) {
+                // Penalize the tile we keep bouncing TO (prev = the "other" tile)
+                this._blockedPos = new RoomPosition(prev.x, prev.y, prev.roomName);
+                this._path = null;
+                this._stuckCount = 0;
+                this._oscillationCount = 0;
+                this._posHistory = [];
+                log.debug(`${this.creepName}: Oscillation detected at (${cur.x},${cur.y})↔(${prev.x},${prev.y}), repathing`);
+            }
+        }
 
         // ── Deep-Stuck Repath ──
         // Fires at stuckCount > 2 (after 3 consecutive no-move ticks).


### PR DESCRIPTION
Fixes a traffic oscillation bug where creeps at junctions get stuck in an infinite swap loop. Root causes were a combination of scoring inversion, intent overwriting, stuck-detection amnesia, and idle workers blocking hatchery corridors.

TrafficManager.ts:
- Blocked mover fallback score: 0.1 → intent.priority + 0.1 (prevents same-priority leapfrogging while preserving right-of-way for higher priority traffic)
- Mutual swap now uses move(blocker) instead of move(direction), with handledSwaps set to prevent the directional move from overwriting the pull() handshake
- Handle blocker-matched-elsewhere case: nudge blocker toward its Gale-Shapley destination instead of silently failing move()
- Parked score reduced from 10000 → 50 (fillers keep 10000); tighten isParked to require container check for harvesters
- Step-aside checks assignedTiles (Gale-Shapley results) in addition to creepAtPos to prevent nudging into tiles another creep is routing into

Zerg.ts:
- Shove detection increments _stuckCount instead of resetting to 0, so repeatedly shoved creeps trigger deep-stuck repath
- Add oscillation detector: tracks last 4 positions, detects A↔B ping-pong pattern, forces repath with tile penalty after 2 cycles

WorkerOverlord.ts:
- Idle workers in hatchery zone now park to DT-based parking zones instead of blocking transporter corridors
- Container anchor filtering skips hatchery containers when fillers are active